### PR TITLE
Making use of the new RESTINIO_USE_EXTERNAL_HTTP_PARSER 

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -47,6 +47,7 @@ class RestinioConan(ConanFile):
         cmake = CMake(self)
         cmake.definitions['RESTINIO_INSTALL'] = True
         cmake.definitions['RESTINIO_FIND_DEPS'] = False
+        cmake.definitions['RESTINIO_USE_EXTERNAL_HTTP_PARSER'] = True
         cmake.definitions['RESTINIO_USE_BOOST_ASIO'] = self.options.boost_libs
         cmake.configure(source_folder = self.source_subfolder + "/dev/restinio")
         return cmake


### PR DESCRIPTION
release with v0.6.5

This is because Conan will provide the expected copy.