### PR TITLE
updating the recipe to follow some best practices

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,16 +5,14 @@ import os
 class RestinioConan(ConanFile):
     name = "restinio"
     version = "0.6.6"
-
     license = "BSD-3-Clause"
     url = "https://github.com/Stiffstream/restinio-conan"
-
+    homepage = "https://github.com/Stiffstream/restinio"
     description = (
             "RESTinio is a header-only C++14 library that gives you "
             "an embedded HTTP/Websocket server."
     )
-
-    settings = "os", "compiler", "build_type", "arch"
+    topics = ( "restinio" , "http", "https", "websocket", "tls", "header-only")
     options = {'boost_libs': ['none', 'static', 'shared'],
                'use_openssl': ['false', 'true'],
                'fmt_header_only': ['false', 'true']}
@@ -22,34 +20,37 @@ class RestinioConan(ConanFile):
                        'use_openssl': 'false',
                        'fmt_header_only': 'false'}
     generators = "cmake"
-    source_subfolder = "restinio"
     build_policy = "missing"
 
+    @property
+    def _source_subfolder(self):
+        return "restinio"
+    
     def requirements(self):
-        self.requires.add("http_parser/2.9.2")
-        self.requires.add("fmt/6.1.2")
+        self.requires("http_parser/2.9.2")
+        self.requires("fmt/6.1.2")
         if self.options.fmt_header_only == "true":
             self.options["fmt"].header_only = True
         else:
             self.options["fmt"].header_only = False
 
         if self.options.boost_libs == "none":
-            self.requires.add("asio/1.12.2")
+            self.requires("asio/1.12.2")
         else:
-            self.requires.add("boost/1.69.0")
+            self.requires("boost/1.69.0")
             if self.options.boost_libs == "shared":
                 self.options["boost"].shared = True
             else:
                 self.options["boost"].shared = False
                 
         if self.options.use_openssl == "true":
-            self.requires.add("openssl/1.1.1d")
+            self.requires("openssl/1.1.1d")
 
     def source(self):
         source_url = "https://github.com/Stiffstream/restinio/releases/download/"
         tools.get("{0}v.{1}/restinio-{1}.zip".format(source_url, self.version))
         extracted_dir = "restinio-" + self.version
-        os.rename(extracted_dir, self.source_subfolder)
+        os.rename(extracted_dir, self._source_subfolder)
 
     def _configure_cmake(self):
         cmake = CMake(self)
@@ -57,7 +58,7 @@ class RestinioConan(ConanFile):
         cmake.definitions['RESTINIO_FIND_DEPS'] = False
         cmake.definitions['RESTINIO_USE_BOOST_ASIO'] = self.options.boost_libs
         cmake.definitions['RESTINIO_FMT_HEADER_ONLY'] = self.options.fmt_header_only
-        cmake.configure(source_folder = self.source_subfolder + "/dev/restinio")
+        cmake.configure(source_folder = self._source_subfolder + "/dev/restinio")
         return cmake
 
     def package(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -44,7 +44,7 @@ class RestinioConan(ConanFile):
                 self.options["boost"].shared = False
                 
         if self.options.use_openssl == "true":
-            self.requires("openssl/1.1.1d")
+            self.requires("openssl/1.1.1g")
 
     def source(self):
         source_url = "https://github.com/Stiffstream/restinio/releases/download/"


### PR DESCRIPTION
There's a handful of errors which are produced using the CCI hooks, these minor teaks make sure the recipe is following the latest conventions based on the changes to the conan tool itself.